### PR TITLE
fix: allow multistage Dockerfiles by removing AS <stage name> in validation

### DIFF
--- a/connect/eaas/core/validation/validators/base.py
+++ b/connect/eaas/core/validation/validators/base.py
@@ -226,7 +226,7 @@ def validate_docker_compose_yml(context):  # noqa: CCR001
                 )
                 continue
             image = from_cmd[4:].split()[0]
-            if image != runner_image:
+            if image.lower() != runner_image.lower():
                 messages.append(
                     ValidationItem(
                         level='ERROR',

--- a/tests/connect/eaas/core/validation/validators/test_base.py
+++ b/tests/connect/eaas/core/validation/validators/test_base.py
@@ -601,6 +601,39 @@ def test_validate_docker_compose_yml_multistage_image_dockerfile(mocker):
     assert len(result.items) == 0
 
 
+def test_validate_docker_compose_yml_dockerfile_case_insensitive(mocker):
+    mocker.patch(
+        'connect.eaas.core.validation.validators.base.os.path.isfile',
+        return_value=True,
+    )
+    mocked_open = mocker.MagicMock()
+    mocked_open.__enter__ = mocker.MagicMock(return_value=mocked_open)
+    mocked_open.__exit__ = mocker.MagicMock(return_value=False)
+    mocked_open.read.return_value = (
+        'FROM CloudBlueConnect/Connect-Extension-Runner:1.0\n'
+    )
+    mocker.patch(
+        'connect.eaas.core.validation.validators.base.open',
+        side_effect=[None, mocked_open],
+    )
+    mocker.patch(
+        'connect.eaas.core.validation.validators.base.yaml.safe_load',
+        return_value={
+            'services': {
+                'dev': {
+                    'build': {'dockerfile': 'Dockerfile'},
+                },
+            },
+        },
+    )
+
+    result = validate_docker_compose_yml({'project_dir': 'fake_dir', 'runner_version': '1.0'})
+
+    assert isinstance(result, ValidationResult)
+    assert result.must_exit is False
+    assert len(result.items) == 0
+
+
 def test_validate_docker_compose_yml_multistage_runner_in_last_stage(mocker):
     mocker.patch(
         'connect.eaas.core.validation.validators.base.os.path.isfile',


### PR DESCRIPTION
fixes #103 
- Modified the validate_docker_compose_yml function to support multistage Dockerfiles.
- Updated the FROM line parsing to remove the AS <stage name> part for case-insensitive comparison.
- This ensures compatibility with Dockerfiles using multistage builds.