### PR TITLE
LITE-34131: Fix get_descriptor() to use inspect.getsourcefile()

### DIFF
--- a/connect/eaas/core/extension.py
+++ b/connect/eaas/core/extension.py
@@ -2,7 +2,6 @@ import functools
 import inspect
 import json
 import os
-from importlib.resources import files
 from typing import Dict, List, Union
 
 import anvil.server
@@ -49,9 +48,15 @@ class ApplicationBase:
             }
             ```
         """
-        return json.load(
-            files(cls.__module__).joinpath('extension.json').open('r'),
+        source_file = inspect.getsourcefile(cls)
+        if source_file is None:
+            source_file = inspect.getfile(cls)
+        descriptor_path = os.path.join(
+            os.path.dirname(source_file),
+            'extension.json',
         )
+        with open(descriptor_path, 'r') as f:
+            return json.load(f)
 
     @classmethod
     def get_variables(cls) -> dict:

--- a/tests/connect/eaas/core/extension.json
+++ b/tests/connect/eaas/core/extension.json
@@ -1,0 +1,6 @@
+{
+    "name": "Test Extension",
+    "description": "A test extension",
+    "version": "1.0.0",
+    "audience": ["vendor"]
+}

--- a/tests/connect/eaas/core/test_extension.py
+++ b/tests/connect/eaas/core/test_extension.py
@@ -132,56 +132,68 @@ def test_get_schedulables():
     assert MyExtension(None, None, None).schedulable1.__doc__ == 'This is schedulable'
 
 
-def test_get_descriptor(tmp_path, monkeypatch):
-    pkg_dir = tmp_path / 'fake_ext'
-    pkg_dir.mkdir()
-    (pkg_dir / '__init__.py').write_text('')
+def test_get_descriptor():
+    # Class defined here means getsourcefile() returns this test file's path,
+    # so it looks for extension.json in this same directory
+    class MyExtension(EventsApplicationBase):
+        pass
+
+    assert MyExtension.get_descriptor() == {
+        'name': 'Test Extension',
+        'description': 'A test extension',
+        'version': '1.0.0',
+        'audience': ['vendor'],
+    }
+
+
+def test_get_descriptor_getsourcefile_returns_none(tmp_path, mocker):
+    ext_dir = tmp_path / 'my_ext'
+    ext_dir.mkdir()
     descriptor = {
         'name': 'Test Extension',
         'description': 'A test extension',
         'version': '1.0.0',
         'audience': ['vendor'],
     }
-    (pkg_dir / 'extension.json').write_text(json.dumps(descriptor))
-
-    monkeypatch.syspath_prepend(str(tmp_path))
+    (ext_dir / 'extension.json').write_text(json.dumps(descriptor))
 
     class MyExtension(EventsApplicationBase):
         pass
 
-    MyExtension.__module__ = 'fake_ext'
+    mocker.patch('inspect.getsourcefile', return_value=None)
+    mocker.patch('inspect.getfile', return_value=str(ext_dir / 'webapp.pyc'))
 
     assert MyExtension.get_descriptor() == descriptor
 
 
-def test_get_descriptor_file_not_found(tmp_path, monkeypatch):
-    pkg_dir = tmp_path / 'fake_ext_no_json'
-    pkg_dir.mkdir()
-    (pkg_dir / '__init__.py').write_text('')
-
-    monkeypatch.syspath_prepend(str(tmp_path))
+def test_get_descriptor_file_not_found(tmp_path, mocker):
+    ext_dir = tmp_path / 'my_ext_no_json'
+    ext_dir.mkdir()
 
     class MyExtension(EventsApplicationBase):
         pass
 
-    MyExtension.__module__ = 'fake_ext_no_json'
+    mocker.patch(
+        'inspect.getsourcefile',
+        return_value=str(ext_dir / 'webapp.py'),
+    )
 
     with pytest.raises(FileNotFoundError):
         MyExtension.get_descriptor()
 
 
-def test_get_descriptor_invalid_json(tmp_path, monkeypatch):
-    pkg_dir = tmp_path / 'fake_ext_bad_json'
-    pkg_dir.mkdir()
-    (pkg_dir / '__init__.py').write_text('')
-    (pkg_dir / 'extension.json').write_text('not valid json{')
-
-    monkeypatch.syspath_prepend(str(tmp_path))
+def test_get_descriptor_invalid_json(tmp_path, mocker):
+    ext_dir = tmp_path / 'my_ext_bad_json'
+    ext_dir.mkdir()
+    (ext_dir / 'extension.json').write_text('not valid json{')
 
     class MyExtension(EventsApplicationBase):
         pass
 
-    MyExtension.__module__ = 'fake_ext_bad_json'
+    mocker.patch(
+        'inspect.getsourcefile',
+        return_value=str(ext_dir / 'webapp.py'),
+    )
 
     with pytest.raises(json.JSONDecodeError):
         MyExtension.get_descriptor()


### PR DESCRIPTION
Instead of broken importlib.resources.files() for non-package modules