### PR TITLE
LITE-33583: Update GitHub Actions to latest stable versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,11 +15,11 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v7
       with:
         fetch-depth: 0
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -37,11 +37,11 @@ jobs:
     needs: [test]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Set up Python 3.10
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
       - name: Install dependencies
@@ -53,7 +53,7 @@ jobs:
         run: |
           poetry run pytest
       - name: SonarCloud
-        uses: SonarSource/sonarcloud-github-action@4006f663ecaf1f8093e8e4abb9227f6041f52216
+        uses: SonarSource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e # v8.2.0
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       - name: SonarQube Quality Gate check

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,9 +8,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v7
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: '3.10'
     - name: Install dependencies
@@ -25,7 +25,7 @@ jobs:
       run: |
         poetry run pytest
     - name: Extract tag name
-      uses: actions/github-script@v6
+      uses: actions/github-script@v9
       id: tag
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What

Bump the GitHub Actions used in CI/CD to their latest stable major versions (all now on the **node24** runtime), and replace the deprecated SonarCloud action.

| action | before | after |
|--------|--------|-------|
| `actions/checkout` | v3 | v7 |
| `actions/setup-python` | v4 | v6 |
| `actions/github-script` | v6 | v9 |
| `SonarSource/sonarcloud-github-action` (deprecated) | v2.2.0 (SHA) | `SonarSource/sonarqube-scan-action@v8.2.0` (SHA-pinned) |

## Notes

- `sonarqube-scan-action` is SonarSource's official drop-in replacement for the deprecated `sonarcloud-github-action`. `SONAR_HOST_URL` is **not** required for SonarQube Cloud, so `SONAR_TOKEN` is unchanged.
- `sonarqube-quality-gate-action@master` left as-is (already floating, no version warning).
- All target versions were verified to exist and run on `node24`.