### PR TITLE
LITE-33583: Bumb to pydantic v2 and newer fastapi

### DIFF
--- a/connect/eaas/core/inject/common.py
+++ b/connect/eaas/core/inject/common.py
@@ -57,7 +57,7 @@ def get_logger(
     )
     return logging.LoggerAdapter(
         logger,
-        context.dict(),
+        context.model_dump(),
     )
 
 

--- a/connect/eaas/core/inject/models.py
+++ b/connect/eaas/core/inject/models.py
@@ -22,13 +22,13 @@ class Context(BaseModel):
     * **call_type** - it can be `admin` if the call came from the same account
         that own the extension otherwise `user`.
     """
-    extension_id: Optional[str]
-    environment_id: Optional[str]
-    environment_type: Optional[Literal['development', 'test', 'production']]
+    extension_id: Optional[str] = None
+    environment_id: Optional[str] = None
+    environment_type: Optional[Literal['development', 'test', 'production']] = None
     installation_id: Optional[str] = None
     tier_account_id: Optional[str] = None
-    user_id: Optional[str]
-    account_id: Optional[str]
-    account_role: Optional[str]
-    call_source: Optional[Literal['ui', 'api']]
-    call_type: Optional[Literal['admin', 'user']]
+    user_id: Optional[str] = None
+    account_id: Optional[str] = None
+    account_role: Optional[str] = None
+    call_source: Optional[Literal['ui', 'api']] = None
+    call_type: Optional[Literal['admin', 'user']] = None

--- a/connect/eaas/core/proto.py
+++ b/connect/eaas/core/proto.py
@@ -7,7 +7,6 @@ from typing import (
 )
 
 from pydantic import BaseModel as PydanticBaseModel, Field
-from pydantic.utils import DUNDER_ATTRIBUTES
 
 from connect.eaas.core.utils import obfuscate_header
 
@@ -33,13 +32,11 @@ class BaseModel(PydanticBaseModel):
         return k, v  # pragma: no cover
 
     def __repr_args__(self):
+        fields = type(self).model_fields
         return [
             self.__obfuscate_args__(k, v)
             for k, v in self.__dict__.items()
-            if (
-                k not in DUNDER_ATTRIBUTES
-                and (k not in self.__fields__ or self.__fields__[k].field_info.repr)
-            )
+            if (k not in fields or fields[k].repr)
         ]
 
 
@@ -59,11 +56,11 @@ class MessageType:
 class TaskOptions(BaseModel):
     task_id: str
     task_category: str
-    correlation_id: Optional[str]
-    reply_to: Optional[str]
-    api_key: Optional[str]
-    installation_id: Optional[str]
-    connect_correlation_id: Optional[str]
+    correlation_id: Optional[str] = None
+    reply_to: Optional[str] = None
+    api_key: Optional[str] = None
+    installation_id: Optional[str] = None
+    connect_correlation_id: Optional[str] = None
 
     def get_sensitive_fields(self):
         return ['api_key']
@@ -71,40 +68,40 @@ class TaskOptions(BaseModel):
 
 class TaskOutput(BaseModel):
     result: str
-    data: Optional[Any]
+    data: Optional[Any] = None
     countdown: int = 0
     runtime: float = 0.0
-    message: Optional[str]
+    message: Optional[str] = None
 
 
 class TaskInput(BaseModel):
     event_type: str
     object_id: str
-    data: Optional[Any]
+    data: Optional[Any] = None
 
 
 class Task(BaseModel):
     options: TaskOptions
     input: TaskInput
-    output: Optional[TaskOutput]
+    output: Optional[TaskOutput] = None
     model_type: Literal['task'] = 'task'
 
 
 class LogMeta(BaseModel):
     repository_tag: Optional[str] = None
-    account_id: Optional[str]
-    account_name: Optional[str]
-    service_id: Optional[str]
+    account_id: Optional[str] = None
+    account_name: Optional[str] = None
+    service_id: Optional[str] = None
     # delete after stop using version 1
-    products: Optional[List[str]]
-    hub_id: Optional[str]
+    products: Optional[List[str]] = None
+    hub_id: Optional[str] = None
 
 
 class Logging(BaseModel):
-    logging_api_key: Optional[str]
-    log_level: Optional[str]
-    runner_log_level: Optional[str]
-    meta: Optional[LogMeta]
+    logging_api_key: Optional[str] = None
+    log_level: Optional[str] = None
+    runner_log_level: Optional[str] = None
+    meta: Optional[LogMeta] = None
 
     def get_sensitive_fields(self):
         return ['logging_api_key']
@@ -118,14 +115,14 @@ class EventDefinition(BaseModel):
 
 
 class SetupResponse(BaseModel):
-    variables: Optional[list]
+    variables: Optional[list] = None
     # delete after stop using version 1
-    environment_type: Optional[str]
-    logging: Optional[Logging]
-    event_definitions: Optional[List[EventDefinition]]
-    environment_runtime: Optional[str]
-    environment_hostname: Optional[str]
-    environment_domain: Optional[str]
+    environment_type: Optional[str] = None
+    logging: Optional[Logging] = None
+    event_definitions: Optional[List[EventDefinition]] = None
+    environment_runtime: Optional[str] = None
+    environment_hostname: Optional[str] = None
+    environment_domain: Optional[str] = None
     model_type: Literal['setup_response'] = 'setup_response'
 
     def get_sensitive_fields(self):
@@ -160,23 +157,23 @@ class Transformation(BaseModel):
 
 
 class Repository(BaseModel):
-    readme_url: Optional[str]
-    changelog_url: Optional[str]
+    readme_url: Optional[str] = None
+    changelog_url: Optional[str] = None
 
 
 class SetupRequest(BaseModel):
     # for version 1 'capabilities' renaming to 'event_subscriptions'
-    event_subscriptions: Optional[dict]
-    ui_modules: Optional[dict]
-    icon: Optional[str]
-    variables: Optional[list]
-    schedulables: Optional[List[Schedulable]]
-    anvil_callables: Optional[list]
-    transformations: Optional[List[Transformation]]
-    audience: Optional[List[Literal['vendor', 'distributor', 'reseller']]]
-    repository: Optional[Repository]
-    runner_version: Optional[str]
-    proxied_connect_api: Optional[Union[list, dict]]
+    event_subscriptions: Optional[dict] = None
+    ui_modules: Optional[dict] = None
+    icon: Optional[str] = None
+    variables: Optional[list] = None
+    schedulables: Optional[List[Schedulable]] = None
+    anvil_callables: Optional[list] = None
+    transformations: Optional[List[Transformation]] = None
+    audience: Optional[List[Literal['vendor', 'distributor', 'reseller']]] = None
+    repository: Optional[Repository] = None
+    runner_version: Optional[str] = None
+    proxied_connect_api: Optional[Union[list, dict]] = None
     model_type: Literal['setup_request'] = 'setup_request'
 
     def get_sensitive_fields(self):
@@ -186,14 +183,14 @@ class SetupRequest(BaseModel):
 class HttpResponse(BaseModel):
     status: int
     headers: dict
-    content: Optional[Any]
+    content: Optional[Any] = None
 
 
 class HttpRequest(BaseModel):
     method: str
     url: str
     headers: dict
-    content: Optional[Any]
+    content: Optional[Any] = None
 
     def get_sensitive_fields(self):
         return ['headers']
@@ -205,15 +202,15 @@ class HttpRequest(BaseModel):
 class WebTaskOptions(BaseModel):
     correlation_id: str
     reply_to: str
-    api_key: Optional[str]
-    installation_id: Optional[str]
-    tier_account_id: Optional[str]
-    connect_correlation_id: Optional[str]
-    user_id: Optional[str]
-    account_id: Optional[str]
-    account_role: Optional[str]
-    call_type: Optional[Literal['admin', 'user']]
-    call_source: Optional[Literal['ui', 'api']]
+    api_key: Optional[str] = None
+    installation_id: Optional[str] = None
+    tier_account_id: Optional[str] = None
+    connect_correlation_id: Optional[str] = None
+    user_id: Optional[str] = None
+    account_id: Optional[str] = None
+    account_role: Optional[str] = None
+    call_type: Optional[Literal['admin', 'user']] = None
+    call_source: Optional[Literal['ui', 'api']] = None
 
     def get_sensitive_fields(self):
         return ['api_key']
@@ -221,8 +218,8 @@ class WebTaskOptions(BaseModel):
 
 class WebTask(BaseModel):
     options: WebTaskOptions
-    request: Optional[HttpRequest]
-    response: Optional[HttpResponse]
+    request: Optional[HttpRequest] = None
+    response: Optional[HttpResponse] = None
     model_type: Literal['web_task'] = 'web_task'
 
 
@@ -233,11 +230,11 @@ class Message(BaseModel):
         WebTask, Task,
         SetupRequest, SetupResponse,
         None,
-    ] = Field(discriminator='model_type')
+    ] = Field(default=None, discriminator='model_type')
 
     def serialize(self, protocol_version=2):
         if protocol_version == 2:
-            return self.dict()
+            return self.model_dump()
 
         if self.message_type == MessageType.SETUP_REQUEST:
             return {

--- a/connect/eaas/core/validation/models.py
+++ b/connect/eaas/core/validation/models.py
@@ -6,13 +6,13 @@ from pydantic import BaseModel
 class ValidationItem(BaseModel):
     level: Literal['WARNING', 'ERROR'] = 'WARNING'
     message: str
-    file: Optional[str]
-    start_line: Optional[int]
-    lineno: Optional[int]
-    code: Optional[str]
+    file: Optional[str] = None
+    start_line: Optional[int] = None
+    lineno: Optional[int] = None
+    code: Optional[str] = None
 
 
 class ValidationResult(BaseModel):
     items: List[ValidationItem] = []
     must_exit: bool = False
-    context: Optional[dict]
+    context: Optional[dict] = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 python = ">=3.9,<3.15"
 connect-openapi-client = ">=25.20"
 pydantic = "^2.9"
-fastapi = "^0.115.0"
+fastapi = ">=0.115,<0.137"
 fastapi-utils = "^0.8.0"
 logzio-python-handler = ">=3.1.1,<4.2"
 anvil-uplink = "^0.5.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = ">=3.9,<3.15"
 connect-openapi-client = ">=25.20"
-pydantic = "^1.10"
+pydantic = "^2.9"
 fastapi = "^0.115.0"
 fastapi-utils = "^0.8.0"
 logzio-python-handler = ">=3.1.1,<4.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,9 @@ connect-openapi-client = ">=25.20"
 pydantic = "^2.9"
 fastapi = ">=0.115,<0.137"
 fastapi-utils = "^0.8.0"
+# fastapi-utils 0.8.0 imports typing_inspect in its pydantic-2 code path
+# but only declares it under its `all` extra; pull it in directly.
+typing-inspect = "^0.9.0"
 logzio-python-handler = ">=3.1.1,<4.2"
 anvil-uplink = "^0.5.2"
 toml = "^0.10.2"

--- a/tests/connect/eaas/core/inject/test_common.py
+++ b/tests/connect/eaas/core/inject/test_common.py
@@ -18,7 +18,7 @@ def test_get_logger_with_logz_handler():
     )
 
     adapter = common.get_logger('api_key', json.dumps(some_metadata), 'INFO', ctx)
-    assert adapter.extra == ctx.dict()
+    assert adapter.extra == ctx.model_dump()
 
     logger = adapter.logger
 
@@ -46,7 +46,7 @@ def test_get_logger_without_logz_handler(mocker):
 
     adapter = common.get_logger(None, None, 'DEBUG', ctx)
 
-    assert adapter.extra == ctx.dict()
+    assert adapter.extra == ctx.model_dump()
 
     logger = adapter.logger
 

--- a/tests/connect/eaas/core/test_proto.py
+++ b/tests/connect/eaas/core/test_proto.py
@@ -213,7 +213,7 @@ def test_deserialize_task_message():
     assert isinstance(message, Message)
     assert message.message_type == MessageType.TASK
     assert isinstance(message.data, Task)
-    assert message.dict() == msg_data
+    assert message.model_dump() == msg_data
     assert isinstance(message.data.options, TaskOptions)
     assert isinstance(message.data.input, TaskInput)
 
@@ -230,7 +230,7 @@ def test_deserialize_setup_response_message():
     assert isinstance(message, Message)
     assert message.message_type == MessageType.SETUP_RESPONSE
     assert isinstance(message.data, SetupResponse)
-    assert message.dict() == msg_data
+    assert message.model_dump() == msg_data
     assert isinstance(message.data.logging, Logging)
     assert isinstance(message.data.logging.meta, LogMeta)
 
@@ -252,7 +252,7 @@ def test_deserialize_setup_request_message():
     assert isinstance(message, Message)
     assert message.message_type == MessageType.SETUP_REQUEST
     assert isinstance(message.data, SetupRequest)
-    assert message.dict() == msg_data
+    assert message.model_dump() == msg_data
     assert isinstance(message.data.repository, Repository)
 
 
@@ -265,13 +265,19 @@ def test_deserialize_setup_request_message_with_vars_and_schedulables():
 
     message = Message.deserialize(msg_data)
 
-    assert message.dict() == msg_data
+    assert message.model_dump() == msg_data
     assert message.data.variables == msg_data['data']['variables']
-    assert message.data.schedulables == msg_data['data']['schedulables']
+    assert (
+        [s.model_dump() for s in message.data.schedulables]
+        == msg_data['data']['schedulables']
+    )
     assert isinstance(message.data.schedulables[0], Schedulable)
     assert message.data.variables[0]['foo'] == msg_data['data']['variables'][0]['foo']
     assert message.data.variables[0]['bar'] == msg_data['data']['variables'][0]['bar']
-    assert message.data.transformations == msg_data['data']['transformations']
+    assert (
+        [t.model_dump() for t in message.data.transformations]
+        == msg_data['data']['transformations']
+    )
     assert isinstance(message.data.transformations[0], Transformation)
 
 
@@ -307,7 +313,7 @@ def test_serialize_v1_task_data():
     assert message.message_type == MessageType.TASK
     assert isinstance(message.data, Task)
 
-    assert message.dict()['data'] == TASK_OUTPUT_DATA
+    assert message.model_dump()['data'] == TASK_OUTPUT_DATA
 
 
 def test_deserialize_v1_setup_response_data():
@@ -323,7 +329,7 @@ def test_deserialize_v1_setup_response_data():
     assert message.message_type == MessageType.SETUP_RESPONSE
     assert isinstance(message.data, SetupResponse)
 
-    assert message.dict()['data'] == SETUP_RESPONSE_DATA
+    assert message.model_dump()['data'] == SETUP_RESPONSE_DATA
 
 
 def test_deserialize_v1_setup_request_data():
@@ -344,7 +350,7 @@ def test_deserialize_v1_setup_request_data():
     assert message.message_type == MessageType.SETUP_REQUEST
     assert isinstance(message.data, SetupRequest)
 
-    assert message.dict()['data'] == expected_data
+    assert message.model_dump()['data'] == expected_data
 
 
 def test_serialize_setup_request_data_to_v1():

--- a/tests/connect/eaas/core/validation/test_models.py
+++ b/tests/connect/eaas/core/validation/test_models.py
@@ -23,7 +23,7 @@ def test_validation_res_to_dict():
     assert isinstance(res, ValidationResult)
     assert isinstance(item1, ValidationItem)
     assert isinstance(item2, ValidationItem)
-    dict_res = res.dict()
+    dict_res = res.model_dump()
 
     assert dict_res['must_exit'] is True
     assert dict_res['context'] == {'ext_class': 'MyAwesomeExtension'}


### PR DESCRIPTION
## Summary

Migrates `connect-eaas-core` from **pydantic v1** to **v2** (`^2.9`), resolving the v1 deprecation warnings that Python 3.13/3.14 emit — the follow-up flagged in #125. Stacked on top of #125 (targets its branch).

Along the way it also widens the fastapi range and fixes a packaging gap that only surfaces once we run on pydantic v2.

## Changes

### pydantic v1 → v2

**Models** (`proto.py`, `inject/models.py`, `validation/models.py`)
- Every `Optional` field gets an explicit `= None` default — in v2 `Optional` no longer implies a default, so these would otherwise become **required** and break deserialization.
- `Message.data` (discriminated union incl. `None`) now defaults to `None`, so omitting it keeps working (e.g. shutdown messages).
- `BaseModel.__repr_args__` drops the removed `pydantic.utils.DUNDER_ATTRIBUTES` import and reads field metadata via `type(self).model_fields`. Sensitive-field obfuscation is unchanged.
- `self.dict()` → `self.model_dump()` (serialize); `context.dict()` → `context.model_dump()`.

**Tests**
- v2 tightened `BaseModel.__eq__` (a model no longer equals a plain dict), so schedulable/transformation assertions compare `model_dump()` output.
- `.dict()` → `.model_dump()`.

### fastapi range: `^0.115.0` → `>=0.115,<0.137`

fastapi began requiring pydantic v2 at **0.128** (its pydantic floor jumped from `>=1.7.4,<3` to `>=2.7`), so this wider range is only reachable now that we run on pydantic v2.

Capped below **0.137**: that release replaced eager route flattening in `include_router` with a lazy `_IncludedRouter` placeholder in `router.routes`, which breaks `WebApplicationBase.get_routers()` (it assumes every entry is an `APIRoute` with `.endpoint`). Lifting the cap requires adapting that code to the new routing model and is tracked separately.

### Declare `typing-inspect`

`fastapi-utils` 0.8.0's `cbv` module imports `typing_inspect` in its pydantic-2 code path but only declares it under its `all` extra. Migrating to pydantic 2 therefore makes importing `connect-eaas-core` crash with `ModuleNotFoundError: typing_inspect` for any consumer that doesn't already pull it in (e.g. connect-cli). Declared directly (matching fastapi-utils' own `>=0.9,<0.10` range) rather than via `fastapi-utils[all]`, which would also drag in `pydantic-settings` and `sqlalchemy`.

## Verification

- **368 passed**, flake8 clean, on `pydantic 2.13.4`.
- Validated at **both ends** of the fastapi range (0.115.x and 0.136.0).
- Reproduced the `typing_inspect` crash from declared deps only, then confirmed the added dependency resolves it.
- No pydantic deprecation warnings remain.

LITE-33583